### PR TITLE
当请求为json格式，请求体为空时会抛出异常

### DIFF
--- a/src/Server/Request/JsonParser.php
+++ b/src/Server/Request/JsonParser.php
@@ -31,7 +31,7 @@ class JsonParser implements RequestParserInterface
     public function parse(string $rawBody, string $contentType): array
     {
         try {
-            $parameters = Json::decode($rawBody, $this->asArray);
+            $parameters = empty($rawBody) ? [] : Json::decode($rawBody, $this->asArray);
             return is_array($parameters) ? $parameters : [];
         } catch (InvalidArgumentException $e) {
             if ($this->throwException) {


### PR DESCRIPTION
一个正常的请求，请求为json格式，请求体为空时会抛出异常