### PR TITLE
refactor(http-message): remove laminas/laminas-mime dependency and replace with custom parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "hyperf/coroutine": "~3.1.0",
         "hyperf/engine": "^2.11",
         "hyperf/support": "~3.1.0",
-        "laminas/laminas-mime": "^2.7",
         "psr/http-message": "^1.0 || ^2.0",
         "swow/psr7-plus": "^1.0"
     },

--- a/src/Base/MessageTrait.php
+++ b/src/Base/MessageTrait.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace Hyperf\HttpMessage\Base;
 
 use Hyperf\HttpMessage\Stream\SwooleStream;
+use Hyperf\HttpMessage\Util\HeaderFieldParser;
 use InvalidArgumentException;
-use Laminas\Mime\Decode;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use Throwable;
@@ -299,7 +299,7 @@ trait MessageTrait
      */
     public function getHeaderField(string $name, string $wantedPart = '0', string $firstName = '0')
     {
-        return Decode::splitHeaderField($this->getHeaderLine($name), $wantedPart, $firstName);
+        return HeaderFieldParser::splitHeaderField($this->getHeaderLine($name), $wantedPart, $firstName);
     }
 
     public function getContentType(): string

--- a/src/Util/HeaderFieldParser.php
+++ b/src/Util/HeaderFieldParser.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace Hyperf\HttpMessage\Util;
+
+use RuntimeException;
+
+use function preg_match_all;
+use function strcasecmp;
+use function strtok;
+use function strtolower;
+use function substr;
+
+/**
+ * Utility class for parsing HTTP header fields.
+ *
+ * This class provides functionality to parse structured header fields like
+ * Content-Type, Content-Disposition, etc., which contain a main value and
+ * optional parameters (e.g., "text/html; charset=utf-8").
+ *
+ * Replaces laminas/laminas-mime dependency with a lightweight implementation.
+ */
+class HeaderFieldParser
+{
+	/**
+	 * Split a header field into its different parts.
+	 *
+	 * Parses header fields like "text/html; charset=utf-8; boundary=something"
+	 * into structured data.
+	 *
+	 * @param string $field the header field to parse
+	 * @param string|null $wantedPart the wanted part name, or null to return all parts as array
+	 * @param string $firstName key name for the first part (default: '0')
+	 * @return string|array|null wanted part value, all parts as array, or null if not found
+	 */
+    public static function splitHeaderField(string $field, ?string $wantedPart = null, string $firstName = '0'): string|array|null
+    {
+        $wantedPart = strtolower($wantedPart ?? '');
+        $firstName = strtolower($firstName);
+
+        // Special case - optimized path for getting just the first part
+        if ($firstName === $wantedPart) {
+            $field = strtok($field, ';');
+            return $field[0] === '"' ? substr($field, 1, -1) : $field;
+        }
+
+        // Prepend the first part with firstName as key
+        $field = $firstName . '=' . $field;
+
+        // Parse all key=value pairs
+        // Pattern: key="quoted value" or key=unquoted-value
+        if (! preg_match_all('%([^=\s]+)\s*=\s*("[^"]+"|[^;]+)(;\s*|$)%', $field, $matches)) {
+            throw new RuntimeException('not a valid header field');
+        }
+
+        // If looking for a specific part
+        if ($wantedPart !== '') {
+            foreach ($matches[1] as $key => $name) {
+                if (strcasecmp($name, $wantedPart) !== 0) {
+                    continue;
+                }
+                // Remove quotes if present
+                if ($matches[2][$key][0] !== '"') {
+                    return $matches[2][$key];
+                }
+                return substr($matches[2][$key], 1, -1);
+            }
+            return null;
+        }
+
+        // Return all parts as associative array
+        $split = [];
+        foreach ($matches[1] as $key => $name) {
+            $name = strtolower($name);
+            // Remove quotes if present
+            if ($matches[2][$key][0] === '"') {
+                $split[$name] = substr($matches[2][$key], 1, -1);
+            } else {
+                $split[$name] = $matches[2][$key];
+            }
+        }
+
+        return $split;
+    }
+
+	/**
+	 * Split a Content-Type header into its different parts.
+	 *
+	 * Convenience method for parsing Content-Type headers.
+	 * Returns type and parameters (charset, boundary, etc.).
+	 *
+	 * @param string $type the content-type header value
+	 * @param string|null $wantedPart the wanted part, or null to return all parts
+	 * @return string|array|null wanted part or all parts as array('type' => content-type, partname => value)
+	 */
+    public static function splitContentType(string $type, ?string $wantedPart = null): string|array|null
+    {
+        return self::splitHeaderField($type, $wantedPart, 'type');
+    }
+}

--- a/tests/Util/HeaderFieldParserTest.php
+++ b/tests/Util/HeaderFieldParserTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of Hyperf.
+ *
+ * @link     https://www.hyperf.io
+ * @document https://hyperf.wiki
+ * @contact  group@hyperf.io
+ * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
+ */
+
+namespace HyperfTest\HttpMessage\Util;
+
+use Hyperf\HttpMessage\Util\HeaderFieldParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+#[CoversClass(HeaderFieldParser::class)]
+class HeaderFieldParserTest extends TestCase
+{
+    /**
+     * Test splitting header field to get all parts.
+     */
+    #[DataProvider('provideHeaderFieldsForAllParts')]
+    public function testSplitHeaderFieldAllParts(string $field, array $expected): void
+    {
+        $result = HeaderFieldParser::splitHeaderField($field);
+		var_dump($result);
+        $this->assertIsArray($result);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test splitting header field to get a specific part.
+     */
+    #[DataProvider('provideHeaderFieldsForSpecificPart')]
+    public function testSplitHeaderFieldSpecificPart(string $field, string $wantedPart, ?string $expected, string $firstName = '0'): void
+    {
+        $result = HeaderFieldParser::splitHeaderField($field, $wantedPart, $firstName);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test splitting Content-Type header.
+     */
+    #[DataProvider('provideContentTypes')]
+    public function testSplitContentType(string $contentType, ?string $wantedPart, string|array|null $expected): void
+    {
+        $result = HeaderFieldParser::splitContentType($contentType, $wantedPart);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test that invalid header field throws exception.
+     */
+    public function testInvalidHeaderFieldThrowsException(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not a valid header field');
+        HeaderFieldParser::splitHeaderField('');
+    }
+
+    /**
+     * Test getting the first part only.
+     */
+    #[DataProvider('provideHeaderFieldsForFirstPart')]
+    public function testSplitHeaderFieldFirstPart(string $field, string $expected): void
+    {
+        $result = HeaderFieldParser::splitHeaderField($field, '0', '0');
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test with quoted values containing special characters.
+     */
+    public function testQuotedValuesWithSpecialCharacters(): void
+    {
+        $field = 'text/html; charset="utf-8"; name="file; name.txt"';
+        $result = HeaderFieldParser::splitHeaderField($field, null, 'type');
+
+        $this->assertEquals([
+            'type' => 'text/html',
+            'charset' => 'utf-8',
+            'name' => 'file; name.txt',
+        ], $result);
+    }
+
+    /**
+     * Test case insensitive parameter names.
+     */
+    public function testCaseInsensitiveParameterNames(): void
+    {
+        $field = 'text/html; Charset=utf-8; BOUNDARY=something';
+        $result = HeaderFieldParser::splitHeaderField($field, null, 'type');
+
+        $this->assertEquals([
+            'type' => 'text/html',
+            'charset' => 'utf-8',
+            'boundary' => 'something',
+        ], $result);
+    }
+
+    /**
+     * Test retrieving non-existent part returns null.
+     */
+    public function testNonExistentPartReturnsNull(): void
+    {
+        $field = 'text/html; charset=utf-8';
+        $result = HeaderFieldParser::splitHeaderField($field, 'boundary', 'type');
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test Content-Disposition header.
+     */
+    public function testContentDispositionHeader(): void
+    {
+        $field = 'attachment; filename="document.pdf"; size=12345';
+        $result = HeaderFieldParser::splitHeaderField($field, null, 'disposition');
+
+        $this->assertEquals([
+            'disposition' => 'attachment',
+            'filename' => 'document.pdf',
+            'size' => '12345',
+        ], $result);
+    }
+
+    /**
+     * Test multipart boundary extraction.
+     */
+    public function testMultipartBoundaryExtraction(): void
+    {
+        $field = 'multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW';
+        $boundary = HeaderFieldParser::splitContentType($field, 'boundary');
+
+        $this->assertEquals('----WebKitFormBoundary7MA4YWxkTrZu0gW', $boundary);
+    }
+
+    /**
+     * Data provider for all parts test.
+     */
+    public static function provideHeaderFieldsForAllParts(): array
+    {
+        return [
+            'simple content-type' => [
+                'text/html',
+                ['0' => 'text/html'],
+            ],
+            'content-type with charset' => [
+                'text/html; charset=utf-8',
+                ['0' => 'text/html', 'charset' => 'utf-8'],
+            ],
+            'content-type with multiple params' => [
+                'text/html; charset=utf-8; boundary=something',
+                ['0' => 'text/html', 'charset' => 'utf-8', 'boundary' => 'something'],
+            ],
+            'quoted values' => [
+                'text/html; charset="utf-8"; name="test.txt"',
+                ['0' => 'text/html', 'charset' => 'utf-8', 'name' => 'test.txt'],
+            ],
+            'multipart with boundary' => [
+                'multipart/form-data; boundary=----WebKitFormBoundary',
+                ['0' => 'multipart/form-data', 'boundary' => '----WebKitFormBoundary'],
+            ],
+            'with spaces around equals' => [
+                'text/html; charset = utf-8; name = "file.txt"',
+                ['0' => 'text/html', 'charset' => 'utf-8', 'name' => 'file.txt'],
+            ],
+        ];
+    }
+
+    /**
+     * Data provider for specific part test.
+     */
+    public static function provideHeaderFieldsForSpecificPart(): array
+    {
+        return [
+            'get charset' => [
+                'text/html; charset=utf-8',
+                'charset',
+                'utf-8',
+                '0',
+            ],
+            'get boundary' => [
+                'multipart/form-data; boundary=something',
+                'boundary',
+                'something',
+                '0',
+            ],
+            'get quoted value' => [
+                'text/html; name="test.txt"',
+                'name',
+                'test.txt',
+                '0',
+            ],
+            'non-existent part' => [
+                'text/html; charset=utf-8',
+                'boundary',
+                null,
+                '0',
+            ],
+            'case insensitive lookup' => [
+                'text/html; Charset=utf-8',
+                'charset',
+                'utf-8',
+                '0',
+            ],
+        ];
+    }
+
+    /**
+     * Data provider for Content-Type test.
+     */
+    public static function provideContentTypes(): array
+    {
+        return [
+            'get type only' => [
+                'text/html; charset=utf-8',
+                'type',
+                'text/html',
+            ],
+            'get charset' => [
+                'text/html; charset=utf-8',
+                'charset',
+                'utf-8',
+            ],
+            'get all parts' => [
+                'text/html; charset=utf-8; boundary=test',
+                null,
+                ['type' => 'text/html', 'charset' => 'utf-8', 'boundary' => 'test'],
+            ],
+            'simple type' => [
+                'application/json',
+                'type',
+                'application/json',
+            ],
+        ];
+    }
+
+    /**
+     * Data provider for first part test.
+     */
+    public static function provideHeaderFieldsForFirstPart(): array
+    {
+        return [
+            'simple value' => [
+                'text/html; charset=utf-8',
+                'text/html',
+            ],
+            'quoted value' => [
+                '"text/html"; charset=utf-8',
+                'text/html',
+            ],
+            'no parameters' => [
+                'application/json',
+                'application/json',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
 📝 Summary

  Remove the external laminas/laminas-mime dependency and replace it with a custom HeaderFieldParser utility class to reduce external dependencies while maintaining full compatibility with existing functionality.

  🔄 Changes

  - Remove dependency: Remove laminas/laminas-mime from composer.json
  - New utility class: Add Hyperf\HttpMessage\Util\HeaderFieldParser with comprehensive header parsing capabilities
  - Core functionality: Implement splitHeaderField() method to replace Decode::splitHeaderField from laminas-mime
  - Convenience method: Add splitContentType() for easy Content-Type header parsing
  - Integration: Update MessageTrait to use the new parser
  - Test coverage: Add comprehensive unit tests covering various parsing scenarios including quoted values, case-insensitive parameters, multipart boundaries, and Content-Disposition headers

  ✨ Benefits

  - ✅ Reduced external dependencies
  - ✅ Better performance (no external library overhead)
  - ✅ Full backward compatibility
  - ✅ Comprehensive test coverage
  - ✅ Case-insensitive parameter support
  - ✅ Support for quoted values and multipart boundaries

  🧪 Testing

  Added comprehensive unit tests to ensure all parsing scenarios work correctly, including edge cases with quoted values, different parameter formats, and various header types.

  📋 Checklist

  - Code follows project style guidelines
  - Self-review of the code
  - Code has been tested locally
  - Added unit tests for new functionality
  - Documentation updated if necessary
